### PR TITLE
Use diffs instead of cloning puzzle for each choice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickbacktrack"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 description = "Library for back tracking with customizable search for moves"
 keywords = ["back", "track", "puzzle", "procedural", "generation"]

--- a/examples/eight_queens.rs
+++ b/examples/eight_queens.rs
@@ -17,10 +17,12 @@ impl Puzzle for EightQueens {
     type Pos = usize;
     type Val = u8;
 
-    fn solve_simple(&mut self) {}
-
     fn set(&mut self, pos: usize, val: u8) {
         self.queens[pos] = val;
+    }
+
+    fn get(&mut self, pos: usize) -> u8 {
+        self.queens[pos]
     }
 
     fn print(&self) {

--- a/examples/knapsack.rs
+++ b/examples/knapsack.rs
@@ -29,14 +29,16 @@ impl Puzzle for Bag {
     type Pos = usize;
     type Val = bool;
 
-    fn solve_simple(&mut self) {}
-
     fn set(&mut self, ind: usize, val: bool) {
         if val {
             self.items |= 1 << ind;
         } else {
             self.items &= !(1 << ind);
         }
+    }
+
+    fn get(&mut self, ind: usize) -> bool {
+        self.items & (1 << ind) == (1 << ind)
     }
 
     fn print(&self) {

--- a/examples/magic_square.rs
+++ b/examples/magic_square.rs
@@ -27,10 +27,12 @@ impl Puzzle for MagicSquare {
     type Pos = [usize; 2];
     type Val = u16;
 
-    fn solve_simple(&mut self) {}
-
     fn set(&mut self, pos: [usize; 2], val: u16) {
         self.slots[pos[1]][pos[0]] = val;
+    }
+
+    fn get(&mut self, pos: [usize; 2]) -> u16 {
+        self.slots[pos[1]][pos[0]]
     }
 
     fn remove(&mut self, other: &MagicSquare) {

--- a/examples/rule_110.rs
+++ b/examples/rule_110.rs
@@ -155,7 +155,7 @@ impl Puzzle for Rule110 {
     type Pos = [usize; 2];
     type Val = u8;
 
-    fn solve_simple(&mut self) {
+    fn solve_simple<F: FnMut(&mut Self, Self::Pos, Self::Val)>(&mut self, mut f: F) {
         loop {
 			let mut found_any = false;
 			for i in 0..self.cells.len() {
@@ -163,7 +163,7 @@ impl Puzzle for Rule110 {
 					if self.cells[i][j] != 0 { continue; }
 					let possible = self.possible([i, j]);
 					if possible.len() == 1 {
-						self.cells[i][j] = possible[0];
+						f(self, [i, j], possible[0]);
 						found_any = true;
 					}
 				}
@@ -175,6 +175,10 @@ impl Puzzle for Rule110 {
     fn set(&mut self, pos: [usize; 2], val: u8) {
         self.cells[pos[0]][pos[1]] = val;
     }
+
+	fn get(&mut self, pos: [usize; 2]) -> u8 {
+		self.cells[pos[0]][pos[1]]
+	}
 
     fn is_solved(&self) -> bool {
         // All cells must be non-empty.

--- a/examples/sudoku.rs
+++ b/examples/sudoku.rs
@@ -22,7 +22,7 @@ impl Puzzle for Sudoku {
 	type Pos = [usize; 2];
 	type Val = u8;
 
-	fn solve_simple(&mut self) {
+	fn solve_simple<F: FnMut(&mut Self, Self::Pos, Self::Val)>(&mut self, mut f: F) {
 		loop {
 			let mut found_any = false;
 			for y in 0..9 {
@@ -30,7 +30,7 @@ impl Puzzle for Sudoku {
 					if self.slots[y][x] != 0 { continue; }
 					let possible = self.possible([x, y]);
 					if possible.len() == 1 {
-						self.slots[y][x] = possible[0];
+						f(self, [x, y], possible[0]);
 						found_any = true;
 					}
 				}
@@ -41,6 +41,10 @@ impl Puzzle for Sudoku {
 
 	fn set(&mut self, pos: [usize; 2], val: u8) {
 		self.slots[pos[1]][pos[0]] = val;
+	}
+
+	fn get(&mut self, pos: [usize; 2]) -> u8 {
+		self.slots[pos[1]][pos[0]]
 	}
 
 	fn remove(&mut self, other: &Sudoku) {

--- a/examples/tsp.rs
+++ b/examples/tsp.rs
@@ -261,10 +261,12 @@ impl Puzzle for Tsp {
     type Pos = usize;
     type Val = Option<(usize, usize)>;
 
-    fn solve_simple(&mut self) {}
-
     fn set(&mut self, pos: usize, val: Option<(usize, usize)>) {
         self.slots[pos] = val;
+    }
+
+    fn get(&mut self, pos: usize) -> Option<(usize, usize)> {
+        self.slots[pos]
     }
 
     fn print(&self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,9 +66,13 @@ pub trait Puzzle: Clone {
     /// Solve simple stuff faster.
     /// This will reduce the number of steps in solution.
     /// If you do not know how to solve this, leave it empty.
-    fn solve_simple(&mut self);
+    ///
+    /// Call the closure when making a simple choice.
+    fn solve_simple<F: FnMut(&mut Self, Self::Pos, Self::Val)>(&mut self, _f: F) {}
     /// Sets a value at position.
     fn set(&mut self, pos: Self::Pos, val: Self::Val);
+    /// Gets value at position.
+    fn get(&mut self, pos: Self::Pos) -> Self::Val;
     /// Print puzzle out to standard output.
     fn print(&self);
     /// Whether puzzle is solved.
@@ -197,8 +201,13 @@ pub struct Solution<T> {
 pub struct BackTrackSolver<T>
     where T: Puzzle
 {
-    /// Stores the states.
-    pub states: Vec<T>,
+    /// Stores the original state.
+    pub original: T,
+    /// Stores the state.
+    pub state: T,
+    /// Stores the previous values of a position before making a choice.
+    /// If the flag is true, the value was inserted due to a simple choice.
+    pub prevs: Vec<(T::Pos, T::Val, bool)>,
     /// Stores the choices for the states.
     pub choice: Vec<(T::Pos, Vec<T::Val>)>,
     /// Search for simple solutions.
@@ -211,7 +220,9 @@ impl<T> BackTrackSolver<T>
     /// Creates a new solver.
     pub fn new(puzzle: T, settings: SolveSettings) -> BackTrackSolver<T> {
         BackTrackSolver {
-            states: vec![puzzle],
+            original: puzzle.clone(),
+            state: puzzle,
+            prevs: vec![],
             choice: vec![],
             settings: settings,
         }
@@ -236,13 +247,15 @@ impl<T> BackTrackSolver<T>
                     sleep(Duration::from_millis(ms));
                 }
             }
-            let n = self.states.len() - 1;
-            let mut new = self.states[n].clone();
             if self.settings.solve_simple {
-                new.solve_simple();
+                let ref mut prevs = self.prevs;
+                self.state.solve_simple(|state, pos, val| {
+                    prevs.push((pos, state.get(pos), true));
+                    state.set(pos, val);
+                });
             }
             if self.settings.debug {
-                new.print();
+                self.state.print();
             }
             iterations += 1;
             if let Some(max_iterations) = self.settings.max_iterations {
@@ -250,20 +263,20 @@ impl<T> BackTrackSolver<T>
                     return None;
                 }
             }
-            if new.is_solved() {
+            if self.state.is_solved() {
                 if self.settings.debug {
                     println!("Solved! Iterations: {}", iterations);
                 }
                 if self.settings.difference {
-                    new.remove(&self.states[0]);
+                    self.state.remove(&self.original);
                 }
-                return Some(Solution { puzzle: new, iterations: iterations, strategy: None });
+                return Some(Solution { puzzle: self.state, iterations: iterations, strategy: None });
             }
 
-            let empty = f(&new);
+            let empty = f(&self.state);
             let mut possible = match empty {
                 None => vec![],
-                Some(x) => g(&new, x)
+                Some(x) => g(&self.state, x)
             };
             if possible.len() == 0 {
                 // println!("No possible at {:?}", empty);
@@ -278,16 +291,26 @@ impl<T> BackTrackSolver<T>
                     let (pos, mut possible) = self.choice.pop().unwrap();
                     if let Some(new_val) = possible.pop() {
                         // Try next choice.
-                        let n = self.states.len() - 1;
-                        self.states[n].set(pos, new_val);
+                        while let Some((old_pos, old_val, simple)) = self.prevs.pop() {
+                            self.state.set(old_pos, old_val);
+                            if !simple {break}
+                        }
+                        self.prevs.push((pos, self.state.get(pos), false));
+                        self.state.set(pos, new_val);
                         self.choice.push((pos, possible));
                         if self.settings.debug {
                             println!("Try   {:?}, {:?} depth {} {} (failed at {:?})",
-                                pos, new_val, self.choice.len(), self.states.len(), empty);
+                                pos, new_val, self.choice.len(), self.prevs.len(), empty);
                         }
                         break;
                     } else {
-                        if self.states.pop().is_none() {
+                        let mut undo = false;
+                        while let Some((old_pos, old_val, simple)) = self.prevs.pop() {
+                            self.state.set(old_pos, old_val);
+                            undo = true;
+                            if !simple {break}
+                        }
+                        if !undo {
                             // No more possible choices.
                             return None;
                         }
@@ -297,12 +320,12 @@ impl<T> BackTrackSolver<T>
                 let empty = empty.unwrap();
                 // Put in the first guess.
                 let v = possible.pop().unwrap();
-                new.set(empty, v);
+                self.prevs.push((empty, self.state.get(empty), false));
+                self.state.set(empty, v);
                 self.choice.push((empty, possible));
-                self.states.push(new);
                 if self.settings.debug {
                     println!("Guess {:?}, {:?} depth {} {}",
-                        empty, v, self.choice.len(), self.states.len());
+                        empty, v, self.choice.len(), self.prevs.len());
                 }
             }
         }
@@ -376,7 +399,7 @@ impl<T> MultiBackTrackSolver<T>
                 let n = states.len() - 1;
                 let mut new = states[n].clone();
                 if self.settings.solve_simple {
-                    new.solve_simple();
+                    new.solve_simple(|state, pos, val| state.set(pos, val));
                 }
                 if self.settings.debug {
                     println!("Strategy {}", i);


### PR DESCRIPTION
Diffs uses much less memory than cloning puzzle for each choice.

- Bumped to 0.4.0
- Added closure to `Puzzle::solve_simple` to handle simple moves
- Made `Puzzle::solve_simple` optional trait method with no moves by default
- Added `Puzzle::get` to read out position value before setting it